### PR TITLE
Removed "require 'pry'", it has no dependency.

### DIFF
--- a/lib/fontawesome/rails/railtie.rb
+++ b/lib/fontawesome/rails/railtie.rb
@@ -1,9 +1,7 @@
-require 'pry'
 module Fontawesome
   module Rails
     class Railtie < ::Rails::Railtie
       config.assets.paths << File.join(File.dirname(__FILE__), '..', '..', '..', 'vendor', 'assets', 'fonts').to_s
-
       config.assets.precompile += %w( .eot .woff .ttf)
     end
   end


### PR DESCRIPTION
This require statement breaks any project that doesn't bundle 'pry' as dependency.
